### PR TITLE
Deals with cross platform script differences

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,9 @@
     "yup": "^0.28.3"
   },
   "scripts": {
-    "start": "set HTTPS=true&&react-scripts start",
+    "start": "run-script-os",
+    "start:windows": "set HTTPS=true&&react-scripts start",
+    "start:nix": "HTTPS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -42,5 +44,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "nan": "^2.14.2",
+    "run-script-os": "^1.1.4"
   }
 }
+


### PR DESCRIPTION
Windows and linux/mac use different start script syntax per https://stackoverflow.com/questions/45082648/npm-package-json-os-specific-script

Note, I'm using Mac, so I have NOT had a chance to confirm that this change works on Windows.

Fixes #1

